### PR TITLE
Add jobStore option for LINC runners

### DIFF
--- a/flocs_runners/linc_runner.py
+++ b/flocs_runners/linc_runner.py
@@ -745,7 +745,7 @@ def calibrator(
     jobStore: Annotated[
         str,
         Parameter(help="Directory in which to put the Toil jobStore."),
-    ] = "<tmpdir_in_rundir>/jobStore",
+    ] = "",
 ):
     args = locals()
     logger.info("Generating LINC Calibrator config")

--- a/flocs_runners/linc_runner.py
+++ b/flocs_runners/linc_runner.py
@@ -183,6 +183,7 @@ class LINCJSONConfig:
         slurm_params: dict = {},
         restart: bool = False,
         record_stats: bool = False,
+        jobStore: str = "",
     ):
         if self.configfile is None:
             raise RuntimeError("No config file has been created. Save it first.")
@@ -286,7 +287,10 @@ class LINCJSONConfig:
             cmd += ["--writeLogs", get_container_env_var("LOGSDIR")]
             cmd += ["--outdir", get_container_env_var("RESULTSDIR")]
             cmd += ["--tmp-outdir-prefix", get_container_env_var("TMPDIR")]
-            cmd += ["--jobStore", os.path.join(self.rundir, "jobstore")]
+            if jobStore=="<tmpdir_in_rundir>/jobStore":
+                cmd += ["--jobStore", os.path.join(self.rundir, "jobstore")]
+            else:
+                cmd += ["--jobStore", jobStore]
             cmd += ["--workDir", workdir]
             if is_ceph:
                 logger.info("Detected CEPH file system, not setting coordinationDir.")
@@ -738,6 +742,10 @@ def calibrator(
             help="Use Toil's stats flag to record statistics. N.B. this disables cleanup of successful steps; make sure there is enough disk space until the end of the run."
         ),
     ] = False,
+    jobStore: Annotated[
+        str,
+        Parameter(help="Directory in which to put the Toil jobStore."),
+    ] = "<tmpdir_in_rundir>/jobStore",
 ):
     args = locals()
     logger.info("Generating LINC Calibrator config")
@@ -762,6 +770,7 @@ def calibrator(
         "restart",
         "record_toil_stats",
         "outdir",
+        "jobStore",
     ]
     args_for_linc = args.copy()
     for key in unneeded_keys:
@@ -785,6 +794,7 @@ def calibrator(
             workdir=args["rundir"],
             restart=args["restart"],
             record_stats=args["record_toil_stats"],
+            jobStore=args["jobStore"],
         )
 
 
@@ -1031,6 +1041,10 @@ def target(
             help="Use Toil's stats flag to record statistics. N.B. this disables cleanup of successful steps; make sure there is enough disk space until the end of the run."
         ),
     ] = False,
+    jobStore: Annotated[
+        str,
+        Parameter(help="Directory in which to put the Toil jobStore."),
+    ] = "<tmpdir_in_rundir>/jobStore",
 ):
     args = locals()
     logger.info("Generating LINC Target config")
@@ -1057,6 +1071,7 @@ def target(
         "restart",
         "record_toil_stats",
         "outdir",
+        "jobStore",
     ]
     args_for_linc = args.copy()
     if args_for_linc["output_fullres_data"]:
@@ -1105,6 +1120,7 @@ def target(
             workdir=args["rundir"],
             restart=args["restart"],
             record_stats=args["record_toil_stats"],
+            jobStore=args["jobStore"],
         )
 
 

--- a/flocs_runners/linc_runner.py
+++ b/flocs_runners/linc_runner.py
@@ -744,7 +744,7 @@ def calibrator(
     ] = False,
     toil_jobstore: Annotated[
         str,
-        Parameter(help="Directory in which to put the Toil jobstore."),
+        Parameter(help="Path/name for the Toil jobStore directory. Relevant memorable name for run recommended if using (e.g. '<your_path>/jobStore-LINC_calibrator-701779' for data with obsid 701779). Default is 'jobstore' within temporary directory created by processing run. N.B. Toil performance may suffer if directory is in BeeGFS file system."),
     ] = "",
 ):
     args = locals()
@@ -1043,7 +1043,7 @@ def target(
     ] = False,
     toil_jobstore: Annotated[
         str,
-        Parameter(help="Directory in which to put the Toil jobStore."),
+        Parameter(help="Path/name for the Toil jobStore directory. Relevant memorable name for run recommended if using (e.g. '<your_path>/jobStore-LINC_target-701783' for data with obsid 701783). Default is 'jobstore' within temporary directory created by processing run. N.B. Toil performance may suffer if directory is in BeeGFS file system."),
     ] = "",
 ):
     args = locals()

--- a/flocs_runners/linc_runner.py
+++ b/flocs_runners/linc_runner.py
@@ -1044,7 +1044,7 @@ def target(
     jobStore: Annotated[
         str,
         Parameter(help="Directory in which to put the Toil jobStore."),
-    ] = "<tmpdir_in_rundir>/jobStore",
+    ] = "",
 ):
     args = locals()
     logger.info("Generating LINC Target config")

--- a/flocs_runners/linc_runner.py
+++ b/flocs_runners/linc_runner.py
@@ -287,7 +287,7 @@ class LINCJSONConfig:
             cmd += ["--writeLogs", get_container_env_var("LOGSDIR")]
             cmd += ["--outdir", get_container_env_var("RESULTSDIR")]
             cmd += ["--tmp-outdir-prefix", get_container_env_var("TMPDIR")]
-            if jobStore=="<tmpdir_in_rundir>/jobStore":
+            if not jobStore:
                 cmd += ["--jobStore", os.path.join(self.rundir, "jobstore")]
             else:
                 cmd += ["--jobStore", jobStore]

--- a/flocs_runners/linc_runner.py
+++ b/flocs_runners/linc_runner.py
@@ -183,7 +183,7 @@ class LINCJSONConfig:
         slurm_params: dict = {},
         restart: bool = False,
         record_stats: bool = False,
-        jobStore: str = "",
+        toil_jobstore: str = "",
     ):
         if self.configfile is None:
             raise RuntimeError("No config file has been created. Save it first.")
@@ -287,10 +287,10 @@ class LINCJSONConfig:
             cmd += ["--writeLogs", get_container_env_var("LOGSDIR")]
             cmd += ["--outdir", get_container_env_var("RESULTSDIR")]
             cmd += ["--tmp-outdir-prefix", get_container_env_var("TMPDIR")]
-            if not jobStore:
+            if not toil_jobstore:
                 cmd += ["--jobStore", os.path.join(self.rundir, "jobstore")]
             else:
-                cmd += ["--jobStore", jobStore]
+                cmd += ["--jobStore", toil_jobstore]
             cmd += ["--workDir", workdir]
             if is_ceph:
                 logger.info("Detected CEPH file system, not setting coordinationDir.")
@@ -742,9 +742,9 @@ def calibrator(
             help="Use Toil's stats flag to record statistics. N.B. this disables cleanup of successful steps; make sure there is enough disk space until the end of the run."
         ),
     ] = False,
-    jobStore: Annotated[
+    toil_jobstore: Annotated[
         str,
-        Parameter(help="Directory in which to put the Toil jobStore."),
+        Parameter(help="Directory in which to put the Toil jobstore."),
     ] = "",
 ):
     args = locals()
@@ -770,7 +770,7 @@ def calibrator(
         "restart",
         "record_toil_stats",
         "outdir",
-        "jobStore",
+        "toil_jobstore",
     ]
     args_for_linc = args.copy()
     for key in unneeded_keys:
@@ -794,7 +794,7 @@ def calibrator(
             workdir=args["rundir"],
             restart=args["restart"],
             record_stats=args["record_toil_stats"],
-            jobStore=args["jobStore"],
+            toil_jobstore=args["toil_jobstore"],
         )
 
 
@@ -1041,7 +1041,7 @@ def target(
             help="Use Toil's stats flag to record statistics. N.B. this disables cleanup of successful steps; make sure there is enough disk space until the end of the run."
         ),
     ] = False,
-    jobStore: Annotated[
+    toil_jobstore: Annotated[
         str,
         Parameter(help="Directory in which to put the Toil jobStore."),
     ] = "",
@@ -1071,7 +1071,7 @@ def target(
         "restart",
         "record_toil_stats",
         "outdir",
-        "jobStore",
+        "toil_jobstore",
     ]
     args_for_linc = args.copy()
     if args_for_linc["output_fullres_data"]:
@@ -1120,7 +1120,7 @@ def target(
             workdir=args["rundir"],
             restart=args["restart"],
             record_stats=args["record_toil_stats"],
-            jobStore=args["jobStore"],
+            toil_jobstore=args["toil_jobstore"],
         )
 
 


### PR DESCRIPTION
Add option to place jobStore for Toil runs in another directory to the default run, which is to place it in the temporary directory created for processing inside the running directory.

"<tmpdir_in_rundir>/jobStore" default could probably be neater, but I wanted it to be slightly informative on what the default location is. Happy for relevant changes to be made.

This update worked when testing myself.